### PR TITLE
Add constructor selection fallback test

### DIFF
--- a/dikt/src/test/kotlin/io/github/vantoozz/dikt/ConstructorSelectionTest.kt
+++ b/dikt/src/test/kotlin/io/github/vantoozz/dikt/ConstructorSelectionTest.kt
@@ -1,0 +1,35 @@
+package io.github.vantoozz.dikt
+
+import io.github.vantoozz.dikt.test.TypeWithTwoConstructors
+import io.github.vantoozz.dikt.test.SomeTypeWithStringDependency
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ConstructorSelectionTest {
+
+    @Test
+    fun `it_uses_constructor_with_dependency`() {
+        val container = KotlinReflectionContainer().apply {
+            put(SomeTypeWithStringDependency("some"))
+        }
+
+        val service = container[TypeWithTwoConstructors::class]
+
+        assertEquals(
+            "Type with two constructors: Some type with string dependency [default]",
+            service?.makeString()
+        )
+    }
+
+    @Test
+    fun it_falls_back_to_default_constructor() {
+        val container = KotlinReflectionContainer()
+
+        val service = container[TypeWithTwoConstructors::class]
+
+        assertEquals(
+            "Type with two constructors: Some type with string dependency [default]",
+            service?.makeString()
+        )
+    }
+}

--- a/dikt/src/test/kotlin/io/github/vantoozz/dikt/test/TypeWithTwoConstructors.kt
+++ b/dikt/src/test/kotlin/io/github/vantoozz/dikt/test/TypeWithTwoConstructors.kt
@@ -1,0 +1,9 @@
+package io.github.vantoozz.dikt.test
+
+internal class TypeWithTwoConstructors(
+    private val dependency: SomeTypeWithStringDependency,
+) {
+    constructor() : this(SomeTypeWithStringDependency("default"))
+
+    fun makeString() = "Type with two constructors: ${dependency.makeString()}"
+}


### PR DESCRIPTION
## Summary
- add `TypeWithTwoConstructors` test helper
- test constructor fallback when dependency is not registered

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6841ba620d708328817e7a1a3cad90f6