### PR TITLE
Refactor constructor resolution and add instantiation tests

### DIFF
--- a/dikt/src/test/kotlin/io/github/vantoozz/dikt/ConstructorInstantiationTest.kt
+++ b/dikt/src/test/kotlin/io/github/vantoozz/dikt/ConstructorInstantiationTest.kt
@@ -1,0 +1,34 @@
+package io.github.vantoozz.dikt
+
+import io.github.vantoozz.dikt.test.CountingService
+import io.github.vantoozz.dikt.test.SomeTypeDependingOnCountingService
+import io.github.vantoozz.dikt.test.SomeTypeDependingOnTwoCountingServices
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ConstructorInstantiationTest {
+
+    @Test
+    fun `it instantiates dependency only once`() {
+        val history = mutableListOf<String>()
+        val container = KotlinReflectionContainer().apply {
+            put { CountingService(history) }
+        }
+
+        container[SomeTypeDependingOnCountingService::class]
+
+        assertEquals(1, history.size)
+    }
+
+    @Test
+    fun `it instantiates dependency only once when used twice`() {
+        val history = mutableListOf<String>()
+        val container = KotlinReflectionContainer().apply {
+            put { CountingService(history) }
+        }
+
+        container[SomeTypeDependingOnTwoCountingServices::class]
+
+        assertEquals(1, history.size)
+    }
+}

--- a/dikt/src/test/kotlin/io/github/vantoozz/dikt/test/CountingService.kt
+++ b/dikt/src/test/kotlin/io/github/vantoozz/dikt/test/CountingService.kt
@@ -1,0 +1,18 @@
+package io.github.vantoozz.dikt.test
+
+internal class CountingService(
+    private val history: MutableList<String>,
+) {
+    init {
+        history.add("created")
+    }
+}
+
+internal class SomeTypeDependingOnCountingService(
+    private val service: CountingService,
+)
+
+internal class SomeTypeDependingOnTwoCountingServices(
+    private val first: CountingService,
+    private val second: CountingService,
+)


### PR DESCRIPTION
## Summary
- streamline constructor instantiation logic
- add counting test classes
- ensure dependencies are created just once during construction

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6841ba5e63b483288b178f5d04380fd2